### PR TITLE
Fix for #58 and update issue.

### DIFF
--- a/amazon-orders.lua
+++ b/amazon-orders.lua
@@ -1420,7 +1420,7 @@ function InitializeSession2 (protocol, bankCode, step, credentials, interactive)
     loginLoops=loginLoops+1
   until(leaveLoginLoop or loginLoops>10)
 
-  if html:xpath(const.xpathOrderMonthForm):length() > 0 then
+  if html:xpath("//form[contains(@action,'order-history')]"):length() > 0 then
     print('login success')
     aName=html:xpath('//span[@class="nav-shortened-name"]'):text()
     if aName == "" then
@@ -1570,7 +1570,7 @@ function RefreshAccount (account, since)
       LocalStorage.invalidCache={}
     end
 
-    local orderFilterSelect=html:xpath('//select[@name="orderFilter"]'):children()
+    local orderFilterSelect=html:xpath('//select[@name="timeFilter"]'):children()
     local numbersOfNewOrders=0
     orderFilterSelect:each(function(index,element)
       local orderFilterVal=element:attr('value')
@@ -1579,8 +1579,8 @@ function RefreshAccount (account, since)
       if string.match(orderFilterVal, "months-") or LocalStorage.orderFilterCache[orderFilterVal] == nil and numbersOfNewOrders < config.limitOrders + 1 then
         MM.printStatus('Get order overview for "'..element:text()..'"')
         --print(orderFilterVal)
-        html:xpath('//*[@name="orderFilter"]'):select(orderFilterVal)
-        html=connectShop(html:xpath(const.xpathOrderMonthForm):submit())
+        html:xpath('//*[@name="timeFilter"]'):select(orderFilterVal)
+        html=connectShop(html:xpath("//form[contains(@action,'orders')]"):submit())
 
         local foundEnd=false
         repeat
@@ -1614,7 +1614,7 @@ function RefreshAccount (account, since)
 
     local newestMessage=LocalStorage.newestMessage
 
-    for orderCode,messageTime in pairs(getMessageList(LocalStorage.newestMessage)) do
+    for orderCode,messageTime in pairs(getMessageList(newestMessage)) do
 
       if newestMessage<messageTime then
         newestMessage=messageTime

--- a/amazon-orders.lua
+++ b/amazon-orders.lua
@@ -88,7 +88,6 @@ local const={
   fixEncoding='latin1',
   differenceText='Difference (shipping costs, coupon etc.)',
   xpathOrderHistoryLink='//a[@id="nav-orders" or contains(@href,"/order-history")]',
-  xpathOrderMonthForm="//form[contains(@action,'order-history')][.//option]",
   orderListLink='/gp/your-account/order-history?unifiedOrders=1',
   monthlyContra="monthy contra",
   yearlyContra="yearly contra",


### PR DESCRIPTION
It looks like Amazon has changed some field in the HTML pages recently.

* The order history form contains now actions like `/gp/your-account/order-history/ref=ppx_yo2ov_dt_b_search`. This action does not match the success criteria for a successful login anymore, which used to be:

```
if html:xpath("//form[contains(@action,'order-history') 
and not(contains(@action,'search'))]"):length() > 0 then ...
```

I don't know why the `and not(contains(@action,'search'))` was there, but removing it helps in fixing #58. @Michael-Beutling please review and verify if this is the proper fix.

* `orderFilter` select form has been renamed to `timeFilter`
*  `order-history` form action has been renamed to `orders`

thanks!

Fixes #58 