### PR TITLE
New order layout 2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Personal data: saved Amazon HTML pages used for local parser tests
+test/pages/
+
+# Plugin runtime artifacts (written by the plugin when run with filesystem access)
+amazon_orders.json
+amazon-debug.log
+webCache/
+
+# Regression-test artifacts (written into MoneyMoney's Data dir at runtime)
+*_transactions.json
+*_transactions_master.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md — Amazon-MoneyMoney plugin
+
+## What this is
+A MoneyMoney web-banking extension (`amazon-orders.lua`) that scrapes a user's
+Amazon.de order history and exposes it as bank-account transactions. It must
+stay a **single, self-contained Lua file** to be recognized by MoneyMoney.
+API docs: https://moneymoney.app/api/webbanking/
+
+## Current task (2026-06)
+Amazon changed the order-history page layout; the scraper's selectors no longer
+match reliably. Goal: update parsing/scraping to the new layout without breaking
+the MoneyMoney plugin contract.
+
+## How MoneyMoney runs the plugin (important constraints)
+- `HTML(content)` parses with **libxml2's HTML parser + XPath** — no JavaScript
+  is executed. So we must target the **raw server HTML** (View Source), NOT the
+  browser's post-JS DOM. If a page is client-side rendered, the data won't be in
+  the raw HTML and we must find the underlying data/endpoint instead.
+- HTML node-set API used by the plugin: `:xpath(q)`, `:text()`, `:attr(name)`,
+  `:attr(name,val)` (setter), `:each(fn(index,el))` (1-based), `:length()`,
+  `:get(n)` (1-based), `:children()`, `:select(val)`, `:submit()`, `:click()`.
+- Signed builds have `io`/`io.open` == nil (no filesystem). Debug/webCache code
+  is guarded on `io ~= nil`.
+
+## Scraper architecture (where the layout-specific selectors live)
+- `enterOrderList()` (~L1094) — navigate to order history.
+- Time/year filter: `const.xpathOrderMonthForm` / `xpathOrderMonthSelect`
+  (`<select name="orderFilter|timeFilter">`) (~L91-92, L1574-1609).
+- Pagination: `//li[contains(@class,"a-last")]/a[@href]` (~L1596).
+- `getOrdersFromSummary(html)` (~L894) — order-list page → order boxes
+  (`#ordersContainer`/`.orders-content-container` → `.order` → `.order-info`).
+- `getOrderInfosFromSummaryHeader()` (~L600) — header values read from
+  `span.a-color-secondary.value` (3/4/5 = customer/business account shapes).
+- `getArticleFromShipment()` (~L716) — item rows `.a-fixed-left-grid-inner`,
+  qty `span.item-view-qty`.
+- `getOrderDetails(order)` (~L860) — detail page `#orderDetails`, subtotals
+  `#od-subtotals`, shipments `.a-box.shipment`, returns `#od-returns-panel`,
+  refund rows `.a-color-success`.
+- Price/date/qty/orderCode helpers: `getPrice`/`getDate`/`getQty`/`getOrderCode`
+  (~L530-586). Order-code regex: `[D%d]%d%d-%d%d%d%d%d%d%d-%d%d%d%d%d%d%d`.
+  Prices: new `€(%d+),(%d%d)`, old `EUR (%d+),(%d%d)`.
+
+## Offline test harness (built, working)
+- Runtime: LuaJIT 2.1 + xmlua (libxml2 binding), installed via Homebrew +
+  `luarocks --lua-version=5.1 install xmlua`. Rocks live in `~/.luarocks`.
+- `test/run.sh <script.lua>` — wrapper that sets PATH + luarocks 5.1 module
+  paths and runs the script under luajit. Use this to run any harness script.
+- `test/mm_shim.lua` — emulates MoneyMoney's host: `HTML()` returning a
+  NodeSet (array-like AND method-bearing) with `:xpath/:text/:attr/:each/`
+  `:length/:get/:children`, plus `loadPlugin(path)` which loads
+  `amazon-orders.lua` into a sandboxed env (stubs MM/JSON/LocalStorage/
+  Connection/WebBanking; io=nil so it behaves like the signed build) and
+  returns the env so tests can call its globals (e.g. `getOrdersFromSummary`).
+- `test/selftest.lua` — runs the real `getOrdersFromSummary` against a synthetic
+  OLD-layout page; passes. Proves the shim + sandbox loading works.
+- `test/pages/` — drop saved raw HTML pages here (named per scenario).
+- The Lua file must stay single-file for MoneyMoney; the harness loads it and
+  calls its global functions rather than modifying its structure.
+- xmlua `node:search(q)` mirrors libxml2 XPath; `//x` is doc-absolute even from
+  a context node, `.//x` / `./x` are relative — same as MoneyMoney.
+
+## New layout findings (2026-06, from saved pages in test/pages/)
+- **Order list** `/your-orders/orders?timeFilter=year-YYYY&startIndex=N`:
+  - Order cards are `div.order-card.js-order-card`; the **card body is encrypted
+    client-side** (Siege CSD, `div.csd-encrypted-sensitive`). MoneyMoney can't
+    decrypt it. BUT the order code is plaintext in
+    `data-csa-c-slot-id="amzn1.yourorders.order-card.<ORDERCODE>"`.
+  - Escape hatch exists: appending `disableCsd=no-js` to the URL makes the server
+    return plaintext cards — currently NOT used (we fetch details instead).
+  - Time filter still `select[name="timeFilter"]#time-filter` in
+    `form.js-time-filter-form` (action `/your-orders/orders`) — existing
+    xpathOrderMonthForm/Select selectors still match. Options: `last30`,
+    `months-3`, `year-YYYY`.
+  - Pagination: `ul.a-pagination li.a-last a[href]` (startIndex steps of 10) —
+    existing selector still matches.
+- **Order details** page (title "Bestelldetails"), still has `div#orderDetails`,
+  now PLAINTEXT with a clean `data-component` interface:
+  - `orderDate` ("20. Dezember 2025"), `orderId` ("304-…").
+  - Items: each `div[data-component="purchasedItemsRightGrid"]` holds sibling
+    `itemTitle`, `unitPrice` (price in `span.a-offscreen`, e.g. "169,98€"),
+    `quantity` (empty = 1), `orderedMerchant`.
+  - Totals: `div.od-line-item-row` rows with `.od-line-item-row-label` /
+    `.od-line-item-row-content`. Grand total = **Gesamtsumme** (bold, last row);
+    e.g. multi: items 33,97 − coupon 1,82 = Gesamtsumme 32,15.
+  - Address: `div[data-component="shippingAddress"]` → `<li>` lines.
+  - **Price format changed**: currency now AFTER amount ("169,98€" / "169,98 €")
+    and the totals use a non-breaking space (`&#160;` = UTF-8 `\194\160`).
+    getPrice now has regexPriceEur + nbsp normalization.
+
+## Architecture change
+Old: list page provided per-order date/total/items; details fetched lazily.
+New: list cards are encrypted, so getOrdersFromSummary only **enumerates order
+codes** (from slot-id) with detailsDate=0; getOrderDetails fetches each order's
+plaintext details page and fills date/total/items/address. Caching unchanged, so
+repeat runs stay fast. detailsUrl built via const.orderDetailsUrl + code.
+
+## Status / TODO
+- DONE & tested (test/test_parse.lua, 5 pages, all pass): list enumeration,
+  single/multi-item detail parsing, totals incl. coupon difference, address,
+  price format + nbsp, REFUND, DIGITAL order, GIFT CARD.
+- CONFIRMED: order-details URL = `/your-orders/order-details?orderID=<code>`
+  (set as const.orderDetailsUrl; legacy /gp/css/... paths 301-redirect here;
+  overridable via the `orderDetailsUrl` account-settings attribute).
+- Refunds: 2024+ layout keeps all items in the summary and adds a
+  "Summe der Erstattung" od-line-item-row. getRefundFromDetails reads that amount
+  and books it as a refundTransaction on the ORDER date (no refund date is in the
+  DOM). getTotalsFromDetails skips "Erstattung" rows so a refund can't be taken
+  for the grand total. Legacy getReturnsFromDetails/getRefundTransActions
+  (od-returns-panel / a-color-success) are no longer called.
+- Digital orders (D01-) and gift cards parse via the same generic detail path
+  (no special URL); gift cards have no shippingAddress, which is fine.
+- STILL PENDING: business account (poNumber/orderedMerchant not wired) needs a
+  sample; per-item partial refund detail; refund date approximated by order date.
+- Minor: address `<br>` between street and city yields "Chattenweg 4Hünfeld"
+  (no space). Cosmetic (endToEndReference only).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,15 @@ repeat runs stay fast. detailsUrl built via const.orderDetailsUrl + code.
   sample; per-item partial refund detail; refund date approximated by order date.
 - Minor: address `<br>` between street and city yields "Chattenweg 4Hünfeld"
   (no space). Cosmetic (endToEndReference only).
+- FIXED (2026-07, from a user-reported MoneyMoney log): `getMessageList()`
+  (~L1086, checks Amazon's message center to flag orders needing a rescan)
+  crashed the whole run. New `/gp/message` layout no longer has the
+  `script[@type contains "a-state"]` it read the ajaxToken from, so
+  `ajaxToken` came back `nil` — but the old `if ajaxToken ~= "" then` check
+  let it fall through anyway into a hardcoded fallback URL that literally sent
+  `token=stateData.token` (a JS placeholder, never a real token) to
+  `/gp/msg/cntr/message-list/`. That 404'd, which the MoneyMoney host turns
+  into a fatal, run-aborting error. Fix: bail out and return no orders when
+  ajaxToken is missing, and removed the dead stateData.token fallback in
+  `getMessageListURL`/`getMessageURL`/`getMessageList` (it never worked).
+  Covered by `test/test_messagelist.lua`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,10 @@ the MoneyMoney plugin contract.
   - `orderDate` ("20. Dezember 2025"), `orderId` ("304-…").
   - Items: each `div[data-component="purchasedItemsRightGrid"]` holds sibling
     `itemTitle`, `unitPrice` (price in `span.a-offscreen`, e.g. "169,98€"),
-    `quantity` (empty = 1), `orderedMerchant`.
+    `quantity` (this component is ALWAYS empty), `orderedMerchant`. The real
+    quantity for qty>1 is a badge over the image: `div.od-item-view-qty > span`
+    in the item's left grid (read via ancestor `a-fixed-left-grid-inner`).
+    `unitPrice` is the PER-ITEM price, so the line total = unitPrice * qty.
   - Totals: `div.od-line-item-row` rows with `.od-line-item-row-label` /
     `.od-line-item-row-content`. Grand total = **Gesamtsumme** (bold, last row);
     e.g. multi: items 33,97 − coupon 1,82 = Gesamtsumme 32,15.

--- a/amazon-orders.lua
+++ b/amazon-orders.lua
@@ -55,6 +55,11 @@ local const={
   regexOrderCodeNew="([D%d]%d%d%-%d%d%d%d%d%d%d%-%d%d%d%d%d%d%d)",
   regexPriceOld="EUR%s+(%d+),(%d%d)",
   regexPriceNew="€(%d+),(%d%d)",
+  -- 2024+ layout writes the currency after the amount, e.g. "169,98€" / "0,00 €"
+  regexPriceEur="(%d+),(%d%d)%s*€",
+  -- order details page; the order code is appended. The legacy /gp/css/... paths
+  -- 301-redirect here. Overridable via the orderDetailsUrl account-setting.
+  orderDetailsUrl="/your-orders/order-details?orderID=",
   str2date = {
     Januar=1,
     January=1,
@@ -196,10 +201,12 @@ if debug ~= nil then
 end
 local baseurl='https://www'..const.domain
 
-WebBanking{version  = 1.23,
+-- NOTE: version must be a Lua number (no letters). To mark this as an
+-- unofficial build the "(beta)" tag is added to the description instead.
+WebBanking{version  = 1.24,
   url         = baseurl,
   services    = const.services,
-  description = const.description}
+  description = const.description.." (beta)"}
 
 function debugBuffer.tablePrint(tbl)
   local t={}
@@ -547,9 +554,15 @@ function getPrice(text)
   if type(text)~='string' then
     return invalidPrice
   end
-  local amountHigh,amountLow=string.match(text:gsub("%.",""),const.regexPriceNew)
+  -- normalize non-breaking spaces (UTF-8 \194\160 and latin1 \160) to plain
+  -- spaces so "%s" matches between amount and currency, then drop thousands dots
+  local stripped=text:gsub("\194\160"," "):gsub("\160"," "):gsub("%.","")
+  local amountHigh,amountLow=string.match(stripped,const.regexPriceEur)
   if amountHigh == nil or amountLow == nil then
-    amountHigh,amountLow=string.match(text:gsub("%.",""),const.regexPriceOld)
+    amountHigh,amountLow=string.match(stripped,const.regexPriceNew)
+  end
+  if amountHigh == nil or amountLow == nil then
+    amountHigh,amountLow=string.match(stripped,const.regexPriceOld)
   end
   --debugBuffer.print(text,amountHigh,amountLow)
   if amountHigh == nil or amountLow == nil then
@@ -567,6 +580,27 @@ function getQty(text)
     return qty
   end
   return invalidQty
+end
+
+function trim(text)
+  if type(text)~='string' then
+    return ''
+  end
+  return (text:gsub('^%s+',''):gsub('%s+$',''):gsub('%s+',' '))
+end
+
+-- 2024+ detail layout: the quantity component is empty for single items and
+-- holds a number (or "Menge: n") otherwise.
+function getQtyNew(text)
+  local n=tonumber((text or ''):match('%d+'))
+  if n ~= nil and n > 0 then
+    return n
+  end
+  return 1
+end
+
+function buildDetailsUrl(orderCode)
+  return const.orderDetailsUrl..orderCode
 end
 
 function getQtyFromElement(element)
@@ -696,16 +730,60 @@ end
 
 
 function getTotalsFromDetails(orderDetails)
-  local totals={} --#totals
+  local totals={orderTotal=invalidPrice,refund=0} --#totals
 
-  local xPathPrefix=('//div[contains(@id,"od-subtotals")]//div[contains(@class,"a-span-last")]//')
-  totals.orderTotal=getPrice(getLastElementText(orderDetails,xPathPrefix,'span[contains(@class,"a-color-base") and contains(@class,"a-text-bold")]'))
-  totals.refund=getPrice(getLastElementText(orderDetails,xPathPrefix,'span[contains(@class,"a-color-success") and contains(@class,"a-text-bold")]'))
-  if totals.refund ==invalidPrice then
-    totals.refund=0
+  -- 2024+ layout: order summary is a list of "od-line-item-row" rows; the grand
+  -- total ("Gesamtsumme") is the bold row. Anchor on the label, fall back to the
+  -- last bold row so we stay robust to localized wording.
+  local labelTotal=invalidPrice
+  local lastBold=invalidPrice
+  orderDetails:xpath('.//div[contains(@class,"od-line-item-row")]'):each(function(index,row)
+    local label=row:xpath('.//*[contains(@class,"od-line-item-row-label")]'):text()
+    local value=getPrice(row:xpath('.//*[contains(@class,"od-line-item-row-content")]'):text())
+    if value ~= invalidPrice and not label:find("Erstattung") then
+      if label:find("Gesamtsumme") or label:find("Grand Total") then
+        labelTotal=value
+      end
+      if row:xpath('.//*[contains(@class,"a-text-bold")]'):length() > 0 then
+        lastBold=value
+      end
+    end
+  end)
+  if labelTotal ~= invalidPrice then
+    totals.orderTotal=labelTotal
+  elseif lastBold ~= invalidPrice then
+    totals.orderTotal=lastBold
   end
+
   return totals
 
+end
+
+--- @function getPositionsFromDetails
+-- 2024+ layout: each purchased item is a "purchasedItemsRightGrid" block holding
+-- data-component itemTitle / unitPrice / quantity. Fills order.orderPositions
+-- and order.orderSum.
+-- @param #table orderDetails
+-- @param #order order
+function getPositionsFromDetails(orderDetails,order)
+  order.orderPositions={}
+  order.orderSum=0
+  orderDetails:xpath('.//*[@data-component="purchasedItemsRightGrid"]'):each(function(index,item)
+    local purpose=trim(item:xpath('.//*[@data-component="itemTitle"]'):text())
+    local priceText=item:xpath('.//*[@data-component="unitPrice"]//*[contains(@class,"a-offscreen")]'):text()
+    if priceText == '' then
+      priceText=item:xpath('.//*[@data-component="unitPrice"]'):text()
+    end
+    local amount=getPrice(priceText)
+    local qty=getQtyNew(item:xpath('.//*[@data-component="quantity"]'):text())
+    if purpose ~= '' and amount ~= invalidPrice then
+      table.insert(order.orderPositions,{purpose=purpose,amount=amount,qty=qty})
+      order.orderSum=order.orderSum+amount*qty
+    else
+      order.invalidArticles=true
+      --debugBuffer.print("invalid article",order.orderCode,purpose,amount,qty)
+    end
+  end)
 end
 
 --- @function  getArticleFromShipment
@@ -829,6 +907,30 @@ function getRefundTransActions(orderDetails,order)
   return
 end
 
+--- @function getRefundFromDetails
+-- 2024+ layout: a refunded/returned order keeps all items in the order summary
+-- and adds a "Summe der Erstattung" row with the refunded amount. There is no
+-- refund date in the DOM, so we book it on the order date (best available).
+-- @param #table orderDetails
+-- @param #order order
+function getRefundFromDetails(orderDetails,order)
+  local bookingDate=order.bookingDate
+  if bookingDate == nil or bookingDate == invalidDate then
+    bookingDate=os.time()
+  end
+  orderDetails:xpath('.//div[contains(@class,"od-line-item-row")][.//*[contains(@class,"od-line-item-row-label")]]'):each(function(index,row)
+    local label=row:xpath('.//*[contains(@class,"od-line-item-row-label")]'):text()
+    if label:find("Erstattung") then
+      local amount=getPrice(row:xpath('.//*[contains(@class,"od-line-item-row-content")]'):text())
+      if amount ~= invalidPrice and amount > 0 then
+        makeBranch(order,{'refundTransactions',bookingDate,amount})
+        --debugBuffer.print("refund",order.orderCode,amount)
+      end
+    end
+  end)
+  return
+end
+
 
 --- @function getOrderaddress
 -- @param #table html
@@ -838,82 +940,95 @@ end
 
 function getOrderaddress(orderDetails,order)
   if order.endToEndReference == nil then
-    local name=orderDetails:xpath('//div[contains(@class,"od-shipping-address-container")]//div[@class="a-row"]'):text()
-    local address=orderDetails:xpath('//div[contains(@class,"od-shipping-address-container")]//div[@class="displayAddressDiv"]'):text()
-
-    if name ~='' and address ~= '' then
-      name=name.." "..address
-    elseif name == '' then
-      name=address
+    -- 2024+ layout: shippingAddress component, address split over <li> items.
+    local parts={}
+    orderDetails:xpath('.//*[@data-component="shippingAddress"]//li'):each(function(index,li)
+      local t=trim(li:text())
+      if t ~= '' then
+        table.insert(parts,t)
+      end
+    end)
+    if #parts == 0 then
+      -- legacy layout fallback
+      local name=orderDetails:xpath('//div[contains(@class,"od-shipping-address-container")]//div[@class="a-row"]'):text()
+      local address=orderDetails:xpath('//div[contains(@class,"od-shipping-address-container")]//div[@class="displayAddressDiv"]'):text()
+      if name ~= '' then table.insert(parts,trim(name)) end
+      if address ~= '' then table.insert(parts,trim(address)) end
     end
-
-    if name ~= '' then
-      order.endToEndReference=name
+    if #parts > 0 then
+      order.endToEndReference=table.concat(parts," ")
     end
   end
 end
 
 --- @function getOrderDetails
+-- Fetches and parses an order's "Bestelldetails" page (2024+ layout). The order
+-- list no longer exposes per-order data (the cards are client-side encrypted),
+-- so the details page is the source of truth for date, total, items and address.
 -- @param #order order
 -- @return
 --
 function getOrderDetails(order)
   debugBuffer.context=order.orderCode
-  if order.detailsUrl ~= "" then
-    --debugBuffer.print("getOrderDetails")
-    local html=connectShopWithCheck("GET",order.detailsUrl)
-    local orderDetails=html:xpath('//div[contains(@id,"orderDetails")]')
-    if orderDetails:text() ~="" then
-      local totals=getTotalsFromDetails(html)
-      --debugBuffer.print("total error",order.orderCode,"order",order.orderTotal , "totals",totals.orderTotal)
-      local doInsert=#order.orderPositions == 0
-      if doInsert then
-        order.orderSum=0
-      end
-      local shipments=orderDetails:xpath('.//div[contains(concat(" ", normalize-space(@class), " "), " a-box shipment ")]')
-      if shipments:text()=='' then
-        shipments=orderDetails:xpath('./div[contains(concat(" ", normalize-space(@class), " "), " a-box ")]')
-      end
-      shipments:each( function(index,shipment)
-        getArticleFromShipment(shipment,order,doInsert)
-      end)
-      getReturnsFromDetails(orderDetails,order)
-      getRefundTransActions(orderDetails,order)
-      getOrderaddress(orderDetails,order)
-      order.detailsDate=os.time()+math.floor((math.random()*90+90)*24*60*60) -- distribute rescans randomly in future
-    else
-      debugBuffer.print("getOrderDetails no details",order.orderCode)
+  if order.detailsUrl == nil or order.detailsUrl == "" then
+    order.detailsUrl=buildDetailsUrl(order.orderCode)
+  end
+  local html=connectShopWithCheck("GET",order.detailsUrl)
+  local orderDetails=html:xpath('//div[contains(@id,"orderDetails")]')
+  if orderDetails:text() ~= "" then
+    local date=getDate(orderDetails:xpath('.//*[@data-component="orderDate"]'):text())
+    if date ~= invalidDate then
+      order.bookingDate=date
     end
+
+    local totals=getTotalsFromDetails(orderDetails)
+    if totals.orderTotal ~= invalidPrice then
+      order.orderTotal=totals.orderTotal
+    end
+    order.refund=totals.refund
+
+    getPositionsFromDetails(orderDetails,order)
+    if order.invalidArticles ~= nil then
+      order.orderPositions={}
+      order.orderSum=0
+      order.invalidArticles=nil
+    end
+
+    getRefundFromDetails(orderDetails,order)
+    getOrderaddress(orderDetails,order)
+    order.detailsDate=os.time()+math.floor((math.random()*90+90)*24*60*60) -- distribute rescans randomly in future
   else
-    -- no handling for digital orders
-    order.detailsDate=os.time()+math.floor((math.random()*90+90)*24*60*60) -- distribute rescans in future
+    debugBuffer.print("getOrderDetails no details",order.orderCode)
   end
   debugBuffer.context=''
 end
 
+--- @function getOrdersFromSummary
+-- 2024+ layout: order cards (div.order-card) carry the order code in their
+-- data-csa-c-slot-id attribute even though the card body is encrypted. We only
+-- enumerate the codes here; getOrderDetails fills in everything else.
 function getOrdersFromSummary(html)
   local orders={}
-  html:xpath('//div[contains(@id,"ordersContainer") or contains(@class,"orders-content-container")]//div[contains(@class," order") and  .//div[contains(@class," order-info")]]'):each(function(index,orderBox)
-    local orderInfo=orderBox:xpath('.//div[contains(@class,"order-info")]')
-    local order={orderPositions={},orderSum=0,refund=0,detailsDate=2} -- #order
-    if getOrderInfosFromSummaryHeader(orderInfo,order) then
-      orderBox:xpath('.//div[not(contains(@class,"order-info"))]//div[contains(@class,"a-box-inner")]'):each(function(index,shipment)
-        if isShipmentShorted(shipment) then
-          order.detailsDate=0
-          --debugBuffer.print("shorted",order.orderCode)
-        else
-          getArticleFromShipment(shipment,order)
-        end
-      end) -- shipment
-      if order.invalidArticles ~= nil then
-        order.orderPositions={}
-        order.invalidArticles=nil
-      end
-      orders[order.orderCode]=order
+  html:xpath('//div[contains(@class,"order-card")]'):each(function(index,card)
+    local orderCode=getOrderCode(card:attr("data-csa-c-slot-id"))
+    if orderCode == nil then
+      orderCode=getOrderCode(card:html())
+    end
+    if orderCode ~= nil and orders[orderCode] == nil then
+      orders[orderCode]={
+        orderCode=orderCode,
+        orderPositions={},
+        orderSum=0,
+        orderTotal=0,
+        refund=0,
+        bookingDate=os.time(),
+        detailsDate=0, -- force detail fetch; the list page has no per-order data
+        detailsUrl=buildDetailsUrl(orderCode),
+      }
     end
     debugBuffer.flush()
     debugBuffer.context=''
-  end) -- orderbox
+  end) -- order card
   return orders
 end
 

--- a/amazon-orders.lua
+++ b/amazon-orders.lua
@@ -1039,7 +1039,6 @@ function getOrdersFromSummary(html)
 end
 
 function getMessageListURL(ajaxToken,page,pageToken)
-  local url='/gp/message/ajax/message-list.html?'
   local fields={
     messageType='all',
     startDateTime=1000,
@@ -1053,25 +1052,16 @@ function getMessageListURL(ajaxToken,page,pageToken)
     stringDebug='',
     isDebug=''
   }
-  if ajaxToken == nil then
-    -- https://www.amazon.de/gp/msg/cntr/message-list/?messageType=all&startDateTime=NaN&endDateTime=NaN&pageSize=10&pageNum=1&sourcePage=inbox&isMobile=0&token=stateData.token&stringDebug=&isDebug=
-    url='/gp/msg/cntr/message-list/?'
-    fields.startDateTime='NaN'
-    fields.endDateTime='NaN'
-    fields.token='stateData.token'
-  end
   local t={}
   for k,v in pairs(fields) do
     if v ~= nil then
       table.insert(t,k..'='..MM.urlencode(v))
     end
   end
-  return url..table.concat(t,"&")
+  return '/gp/message/ajax/message-list.html?'..table.concat(t,"&")
 end
 
 function getMessageURL(ajaxToken,messageId,threadId,messageDateTime)
---https://www.amazon.de/gp/msg/cntr/message-content/?messageId=urn%3Artn%3Amsg%&threadId=&messageType=all&sourcePage=inbox&messageDateTime=16667&isMobile=0&token=stateData.token&stringDebug=&isDebug=
-  local url
   local fields={
     messageId=messageId,
     threadId=threadId,
@@ -1083,19 +1073,13 @@ function getMessageURL(ajaxToken,messageId,threadId,messageDateTime)
     stringDebug='',
     isDebug=''
   }
-  if ajaxToken == nil then
-    url='/gp/msg/cntr/message-content/?'
-    fields.token='stateData.token'
-  else
-    url='/gp/message/ajax/message-content.html?'
-  end
   local t={}
   for k,v in pairs(fields) do
     if v ~= nil then
       table.insert(t,k..'='..MM.urlencode(v))
     end
   end
-  return url..table.concat(t,"&")
+  return '/gp/message/ajax/message-content.html?'..table.concat(t,"&")
 end
 
 
@@ -1106,80 +1090,70 @@ function getMessageList(since)
   local ajaxToken=html:xpath('//script[contains(@type,"a-state")]'):text()
   ajaxToken=string.match(ajaxToken,'{"token":"([A-Za-z0-9]+)"}')
   print("ajaxToken",ajaxToken)
-  if ajaxToken ~= "" then
-    local page=1
-    local messages={}
-    local nextPageToken
-    repeat
-      MM.printStatus("Get page",page,"from Amazon message center.")
-      local html
-      local noNextPage=true
-        --debugBuffer.print(page,json)
-      if ajaxToken ~= nil then
-        local json=connectShopJson("GET",getMessageListURL(ajaxToken,page,nextPageToken))
-        if json.html ~= nil then
-          html=HTML("<html><body>"..json['html'].."</html></body>")
-          json.html = nil
-        end
-        if json.nextPageToken~= nil then
-          nextPageToken=json.nextPageToken
-          noNextPage=true
-        end
-      else
-        html=connectShop("GET",getMessageListURL(ajaxToken,page,nextPageToken))
-        
-        nextPageToken=html:xpath("//div[@id='nextPageTokenValue']"):attr('data-val')
-        if nextPageToken ~= '' then
-          noNextPage=false
-        end
-      end
-      --debugBuffer.flush()
-      
-      local newMessages=false
-      html:xpath('//td'):each(function(index,td)
-        local message={}
-        for _,k in pairs({'messageSentTime','message-sent-time-in-ms','messageId','message-id','threadId','thread-id'}) do
-          message[k]=td:attr(k:lower())
-        end
-        if message['message-sent-time-in-ms'] ~= '' then
-          message.messageSentTime=message['message-sent-time-in-ms']
-          message.threadId=message['threadId']
-          message.messageId=message['message-id']
-        end
-        if tonumber(message.messageSentTime) > since then
-          messages[message.messageId]=message
-          newMessages=true
-        end
-        debugBuffer.print(message)
-      end)
-      --debugBuffer.print(page,json)
-      if not newMessages then
-        noNextPage=true
-      end
-      page=page+1
-    until noNextPage
-    local numAll=0
-    local num=0
-    for _,v in pairs(messages) do
-      numAll=numAll+1
+  if ajaxToken == nil or ajaxToken == "" then
+    -- new page layout no longer exposes the a-state token; skip the
+    -- message-center check rather than guess at a broken request URL
+    print("no ajaxToken found, skipping Amazon message center check")
+    return orderIds
+  end
+  local page=1
+  local messages={}
+  local nextPageToken
+  repeat
+    MM.printStatus("Get page",page,"from Amazon message center.")
+    local html
+    local noNextPage=true
+    local json=connectShopJson("GET",getMessageListURL(ajaxToken,page,nextPageToken))
+    if json.html ~= nil then
+      html=HTML("<html><body>"..json['html'].."</html></body>")
+      json.html = nil
     end
-    for _,v in pairs(messages) do
-      num=num+1
-      MM.printStatus("Get Amazon message",num,"of",numAll)
-      local html
-      if ajaxToken ~= nil then
-        local json=connectShopJson("GET",getMessageURL(ajaxToken,v.messageId,v.threadId,v.messageSentTime))
-        if json.html ~= nil then
-          html=HTML("<html><body>"..json['html'].."</html></body>")
-        else
-          html=''
-        end
-      else
-        html=connectShop("GET",getMessageURL(ajaxToken,v.messageId,v.threadId,v.messageSentTime))
+    if json.nextPageToken~= nil then
+      nextPageToken=json.nextPageToken
+      noNextPage=true
+    end
+    --debugBuffer.flush()
+
+    local newMessages=false
+    html:xpath('//td'):each(function(index,td)
+      local message={}
+      for _,k in pairs({'messageSentTime','message-sent-time-in-ms','messageId','message-id','threadId','thread-id'}) do
+        message[k]=td:attr(k:lower())
       end
-      for orderId in html:html():gmatch(const.regexOrderCodeNew) do
-        orderIds[orderId]=tonumber(v.messageSentTime)/1000 -- in milliseconds
+      if message['message-sent-time-in-ms'] ~= '' then
+        message.messageSentTime=message['message-sent-time-in-ms']
+        message.threadId=message['threadId']
+        message.messageId=message['message-id']
       end
+      if tonumber(message.messageSentTime) > since then
+        messages[message.messageId]=message
+        newMessages=true
+      end
+      debugBuffer.print(message)
+    end)
+    --debugBuffer.print(page,json)
+    if not newMessages then
+      noNextPage=true
+    end
+    page=page+1
+  until noNextPage
+  local numAll=0
+  local num=0
+  for _,v in pairs(messages) do
+    numAll=numAll+1
+  end
+  for _,v in pairs(messages) do
+    num=num+1
+    MM.printStatus("Get Amazon message",num,"of",numAll)
+    local html
+    local json=connectShopJson("GET",getMessageURL(ajaxToken,v.messageId,v.threadId,v.messageSentTime))
+    if json.html ~= nil then
+      html=HTML("<html><body>"..json['html'].."</html></body>")
+    else
+      html=''
+    end
+    for orderId in html:html():gmatch(const.regexOrderCodeNew) do
+      orderIds[orderId]=tonumber(v.messageSentTime)/1000 -- in milliseconds
     end
   end
   local numOrders=0

--- a/amazon-orders.lua
+++ b/amazon-orders.lua
@@ -775,7 +775,13 @@ function getPositionsFromDetails(orderDetails,order)
       priceText=item:xpath('.//*[@data-component="unitPrice"]'):text()
     end
     local amount=getPrice(priceText)
-    local qty=getQtyNew(item:xpath('.//*[@data-component="quantity"]'):text())
+    -- quantity (>1) is shown as a badge over the item image (od-item-view-qty)
+    -- in the enclosing item container, NOT in the (empty) quantity component.
+    local qtyText=item:xpath('ancestor::div[contains(concat(" ",normalize-space(@class)," ")," a-fixed-left-grid-inner ")][1]//div[contains(@class,"od-item-view-qty")]'):text()
+    if qtyText == '' then
+      qtyText=item:xpath('.//*[@data-component="quantity"]'):text()
+    end
+    local qty=getQtyNew(qtyText)
     if purpose ~= '' and amount ~= invalidPrice then
       table.insert(order.orderPositions,{purpose=purpose,amount=amount,qty=qty})
       order.orderSum=order.orderSum+amount*qty

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,88 @@
+# Offline test harness
+
+MoneyMoney runs `amazon-orders.lua` inside its own host, parsing Amazon HTML with
+libxml2 (HTML parser + XPath) — **no JavaScript is executed**. This harness lets
+you run the plugin's parsing functions against *saved* Amazon pages on your own
+machine, so you can adjust selectors when Amazon changes its layout without
+needing a live login each time.
+
+It emulates the MoneyMoney host environment on top of LuaJIT + libxml2, loads the
+real (unmodified) `amazon-orders.lua`, and calls its global functions
+(`getOrdersFromSummary`, `getOrderDetails`, …) against HTML files you provide.
+
+## Prerequisites (one-time)
+
+```sh
+brew install luajit luarocks
+luarocks --lua-version=5.1 install xmlua   # libxml2 binding (pulls luacs, luautf8)
+```
+
+`xmlua` installs into `~/.luarocks` for Lua 5.1 (LuaJIT). `test/run.sh` wires up
+the right module paths for you.
+
+## Running the tests
+
+```sh
+./test/run.sh test/selftest.lua     # sanity check: shim works (synthetic page)
+./test/run.sh test/test_parse.lua   # real tests against pages in test/pages/
+```
+
+`test/run.sh <script.lua>` just sets `PATH` + the luarocks 5.1 module paths and
+runs the script under `luajit`. You can point it at any Lua script.
+
+## Providing test pages
+
+`test/test_parse.lua` reads HTML files from `test/pages/` (gitignored — they
+contain personal data and are never committed). The expected files are named per
+scenario, e.g. `list.html`, `details-single.html`, `details-multi.html`,
+`details-multi-with-refund.html`, `details-digital.html`, `details-giftcard.html`.
+
+To capture a page the way the plugin actually receives it, save the **raw server
+HTML**, not the browser's post-JavaScript DOM:
+
+- Best: open the page, **View Source** (`Cmd+Option+U`), then `Cmd+S`.
+- Or: DevTools → **Network** → reload → click the top "document" request →
+  **Response** tab → copy that HTML.
+- Avoid "Save Page As → Complete", which can capture the rendered DOM.
+
+Sanity check after saving: you should be able to find your real order numbers /
+product titles as plain text in the file. If a page is mostly empty `<div>`s and
+scripts, Amazon is rendering it client-side and the plugin can't parse it as-is
+(see the order-list note below).
+
+## Files
+
+- `mm_shim.lua` — emulates the host. `HTML(content)` returns a NodeSet that is
+  both array-like (`result[1]`) and method-bearing (`:xpath/:text/:attr/:each/`
+  `:length/:get/:children`). `loadPlugin(path)` loads `amazon-orders.lua` into a
+  sandbox (stubbing `MM`/`JSON`/`LocalStorage`/`Connection`/`WebBanking`; `io=nil`
+  so it behaves like the signed build) and returns its environment table.
+- `test_parse.lua` — the actual assertions over `test/pages/`.
+- `selftest.lua` — validates the shim against a synthetic page (no real data).
+- `skeleton.py` — stdlib-only HTML structure explorer; prints an indented tree of
+  tags/classes/text, skipping `<script>`/`<style>` noise. Handy for
+  reverse-engineering a new layout:
+  `python3 test/skeleton.py PAGE.html --class order-card --nth 0 --max-depth 8`
+- `run.sh` — luajit launcher with module paths set.
+
+## Layout notes (what to watch when Amazon changes things)
+
+- **Order list** (`/your-orders/orders`): order *cards* are encrypted
+  client-side, but the order code is plaintext in `data-csa-c-slot-id`. The
+  plugin only enumerates codes from the list, then fetches each (plaintext)
+  details page. The time-filter `<select name="timeFilter">` and `li.a-last`
+  pagination are still plaintext.
+- **Order details** (`/your-orders/order-details?orderID=…`): plaintext, with a
+  clean `data-component` interface (`orderDate`, `orderId`,
+  `purchasedItemsRightGrid` → `itemTitle`/`unitPrice`/`quantity`, the
+  `od-line-item-row` totals incl. `Gesamtsumme`, `shippingAddress`,
+  `Summe der Erstattung` for refunds). Prefer `data-component` anchors over CSS
+  classes — they have been the most stable.
+
+See `../CLAUDE.md` for the full layout/architecture write-up.
+
+## Constraint
+
+`amazon-orders.lua` must remain a **single self-contained file** to be recognized
+by MoneyMoney. The harness loads it and calls its globals; it never splits or
+modifies the plugin's structure.

--- a/test/mm_shim.lua
+++ b/test/mm_shim.lua
@@ -1,0 +1,181 @@
+-- mm_shim.lua
+-- Emulates the MoneyMoney WebBanking host environment well enough to run the
+-- parsing functions of amazon-orders.lua against saved HTML pages offline.
+--
+-- The real host parses HTML with libxml2 (HTML parser + XPath); we wrap xmlua
+-- (a libxml2 binding) to mirror the node-set API the plugin relies on:
+--   :xpath(q) :text() :attr(n[,v]) :each(fn) :length() :get(n) :children()
+-- Form/navigation methods (:submit/:click/:select) are stubbed because offline
+-- tests exercise parsing, not live scraping.
+
+local xmlua = require("xmlua")
+
+local M = {}
+
+----------------------------------------------------------------------
+-- NodeSet: array-like (result[1] is the first element) AND method-bearing.
+-- Every "element" handed to plugin code is itself a single-node NodeSet, so
+-- element:text()/:attr()/:xpath() all work uniformly.
+----------------------------------------------------------------------
+local NodeSet = {}
+NodeSet.__index = NodeSet
+
+local function single(node, doc)
+  local o = setmetatable({ _nodes = { node }, _doc = doc }, NodeSet)
+  o[1] = o
+  return o
+end
+
+local function wrap(nodes, doc)
+  local o = setmetatable({ _nodes = nodes, _doc = doc }, NodeSet)
+  for i, n in ipairs(nodes) do
+    o[i] = single(n, doc)
+  end
+  return o
+end
+
+-- libxml2 searches `//x` from the document regardless of context node, and
+-- `.//x` / `./x` relative to the context node. We run the query from the first
+-- node of the set (matching how the plugin always uses single-node contexts).
+function NodeSet:xpath(query)
+  local ctx = self._nodes[1]
+  if ctx == nil then
+    return wrap({}, self._doc)
+  end
+  local ok, res = pcall(function() return ctx:search(query) end)
+  if not ok or res == nil then
+    return wrap({}, self._doc)
+  end
+  local nodes = {}
+  for _, n in ipairs(res) do nodes[#nodes + 1] = n end
+  return wrap(nodes, self._doc)
+end
+
+function NodeSet:text()
+  local n = self._nodes[1]
+  if n == nil then return "" end
+  local ok, t = pcall(function() return n:text() end)
+  if not ok or t == nil then return "" end
+  return t
+end
+
+function NodeSet:attr(name, value)
+  local n = self._nodes[1]
+  if value ~= nil then
+    if n ~= nil and n.set_attribute then
+      pcall(function() n:set_attribute(name, value) end)
+    end
+    return self
+  end
+  if n == nil then return "" end
+  local ok, v = pcall(function() return n:get_attribute(name) end)
+  if not ok or v == nil then return "" end
+  return v
+end
+
+function NodeSet:each(fn)
+  for i = 1, #self._nodes do
+    local cont = fn(i, self[i])
+    if cont == false then break end
+  end
+  return self
+end
+
+function NodeSet:length()
+  return #self._nodes
+end
+
+function NodeSet:get(n)
+  return self[n] or wrap({}, self._doc)
+end
+
+-- element children (skip text nodes) — matches how the plugin uses :children()
+function NodeSet:children()
+  return self:xpath("./*")
+end
+
+function NodeSet:html()
+  local n = self._nodes[1]
+  if n == nil then return "" end
+  local ok, h = pcall(function() return n:to_html() end)
+  if not ok or h == nil then return "" end
+  return h
+end
+
+-- navigation stubs: error loudly so a test that hits them is obvious
+local function navStub(name)
+  return function()
+    error("mm_shim: NodeSet:" .. name .. "() called — not supported offline")
+  end
+end
+NodeSet.select = navStub("select")
+NodeSet.submit = navStub("submit")
+NodeSet.click  = navStub("click")
+
+----------------------------------------------------------------------
+-- HTML(content) host function
+----------------------------------------------------------------------
+function M.HTML(content)
+  local doc = xmlua.HTML.parse(content or "")
+  local root = doc:root()
+  if root == nil then
+    return wrap({}, doc)
+  end
+  return single(root, doc)
+end
+
+----------------------------------------------------------------------
+-- Sandbox: load amazon-orders.lua with host globals stubbed, return its env
+-- so tests can call its global functions (getOrdersFromSummary, etc.).
+----------------------------------------------------------------------
+function M.loadPlugin(path)
+  local env = {}
+
+  local MM = {
+    md5 = function(s) return tostring(s) end,
+    base64 = function(s) return s end,
+    urlencode = function(s) return tostring(s) end,
+    toEncoding = function(_, s) return s end,
+    printStatus = function() end,
+    sleep = function() end,
+  }
+
+  local JSONmeta = {}
+  JSONmeta.__index = JSONmeta
+  function JSONmeta:dictionary() return self._d or {} end
+  function JSONmeta:set(d) self._d = d; return self end
+  function JSONmeta:json() return "{}" end
+  local function JSON(s)
+    return setmetatable({ _d = {} }, JSONmeta)
+  end
+
+  -- Provide standard library + host stubs; fall back to real _G for the rest.
+  local overrides = {
+    HTML = M.HTML,
+    MM = MM,
+    JSON = JSON,
+    LocalStorage = nil,             -- nil => top-level cache block is skipped
+    Connection = function() error("Connection() not available offline") end,
+    WebBanking = function() end,
+    ProtocolWebBanking = "ProtocolWebBanking",
+    AccountTypeOther = "AccountTypeOther",
+    LoginFailed = "LoginFailed",
+    io = nil,                       -- nil => behaves like signed build (no fs)
+    print = function(...) end,      -- silence plugin's load-time prints
+  }
+  setmetatable(env, { __index = function(t, k)
+    local v = overrides[k]
+    if v ~= nil then return v end
+    return _G[k]
+  end })
+
+  local chunk, err = loadfile(path)
+  if not chunk then error("loadfile failed: " .. tostring(err)) end
+  setfenv(chunk, env)
+  chunk()
+  return env
+end
+
+M.NodeSet = NodeSet
+M.wrap = wrap
+return M

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+# Run a Lua test script under luajit with the luarocks 5.1 module paths set up.
+# Usage: test/run.sh test/selftest.lua   (or any harness script)
+export PATH="/opt/homebrew/bin:$PATH"
+eval "$(luarocks --lua-version=5.1 path)"
+cd "$(dirname "$0")/.."
+exec luajit "${1:-test/selftest.lua}" "${@:2}"

--- a/test/selftest.lua
+++ b/test/selftest.lua
@@ -1,0 +1,37 @@
+-- Validates the shim mechanics by running the real plugin function
+-- getOrdersFromSummary() against a synthetic OLD-layout order-list page.
+-- Run: luajit test/selftest.lua   (with luarocks 5.1 paths exported)
+package.path = "./test/?.lua;" .. package.path
+local mm = require("mm_shim")
+
+local env = mm.loadPlugin("amazon-orders.lua")
+
+local page = [[
+<html><body>
+<div id="ordersContainer">
+  <div class="a-box-group order">
+    <div class="a-box a-spacing-base order-info">
+      <div class="a-row">
+        <span class="a-color-secondary value">12. Juni 2026</span>
+        <span class="a-color-secondary value">EUR 19,99</span>
+        <span class="a-color-secondary value">302-1234567-1234567</span>
+      </div>
+      <a class="a-link-normal" href="/gp/your-account/order-details/?orderID=302-1234567-1234567">Details</a>
+    </div>
+  </div>
+</div>
+</body></html>]]
+
+local html = mm.HTML(page)
+local orders = env.getOrdersFromSummary(html)
+
+local count = 0
+for code, order in pairs(orders) do
+  count = count + 1
+  print(string.format("order=%s date=%s total=%s detailsUrl=%s",
+    code, os.date("%Y-%m-%d", order.bookingDate), tostring(order.orderTotal), order.detailsUrl))
+  assert(code == "302-1234567-1234567", "unexpected order code: " .. tostring(code))
+  assert(order.orderTotal == 1999, "unexpected total: " .. tostring(order.orderTotal))
+end
+assert(count == 1, "expected exactly 1 order, got " .. count)
+print("SELFTEST OK")

--- a/test/skeleton.py
+++ b/test/skeleton.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Print an indented skeleton (tags + class + short text) of HTML, skipping
+script/style noise. Used to reverse-engineer Amazon's new order layout.
+
+Usage:
+  skeleton.py FILE [--class SUBSTR] [--nth N] [--max-depth D] [--max-text N]
+If --class is given, only print subtrees rooted at the Nth element whose class
+contains SUBSTR (0-based; default all matches).
+"""
+import sys
+from html.parser import HTMLParser
+
+VOID = {"area","base","br","col","embed","hr","img","input","link","meta",
+        "param","source","track","wbr"}
+SKIP = {"script","style","noscript","svg"}
+
+class Node:
+    def __init__(self, tag, attrs):
+        self.tag = tag
+        self.attrs = dict(attrs)
+        self.children = []
+        self.text = ""
+
+class Builder(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.root = Node("#root", [])
+        self.stack = [self.root]
+        self.skip_depth = 0
+    def handle_starttag(self, tag, attrs):
+        if self.skip_depth:
+            if tag in SKIP: self.skip_depth += 1
+            return
+        if tag in SKIP:
+            self.skip_depth = 1
+            return
+        n = Node(tag, attrs)
+        self.stack[-1].children.append(n)
+        if tag not in VOID:
+            self.stack.append(n)
+    def handle_endtag(self, tag):
+        if self.skip_depth:
+            if tag in SKIP: self.skip_depth -= 1
+            return
+        if tag in VOID: return
+        for i in range(len(self.stack) - 1, 0, -1):
+            if self.stack[i].tag == tag:
+                del self.stack[i:]
+                break
+    def handle_data(self, data):
+        if self.skip_depth: return
+        t = data.strip()
+        if t:
+            self.stack[-1].text += (" " if self.stack[-1].text else "") + t
+
+def find(node, substr, out):
+    cls = node.attrs.get("class", "")
+    if substr in cls:
+        out.append(node)
+        return  # don't descend into matches-of-matches
+    for c in node.children:
+        find(c, substr, out)
+
+def pp(node, depth, max_depth, max_text):
+    if depth > max_depth: return
+    ind = "  " * depth
+    bits = [node.tag]
+    cls = node.attrs.get("class")
+    if cls: bits.append("." + ".".join(cls.split()))
+    nid = node.attrs.get("id")
+    if nid: bits.append("#" + nid)
+    for k in ("href", "data-csa-c-slot-id", "name", "value", "aria-label"):
+        if k in node.attrs:
+            v = node.attrs[k]
+            if len(v) > 80: v = v[:80] + "…"
+            bits.append(f'{k}="{v}"')
+    line = ind + " ".join(bits)
+    own = node.text
+    if own:
+        if len(own) > max_text: own = own[:max_text] + "…"
+        line += f"   ⟨{own}⟩"
+    print(line)
+    for c in node.children:
+        pp(c, depth + 1, max_depth, max_text)
+
+def main():
+    args = sys.argv[1:]
+    path = args[0]
+    substr = None; nth = None; max_depth = 40; max_text = 60
+    i = 1
+    while i < len(args):
+        if args[i] == "--class": substr = args[i+1]; i += 2
+        elif args[i] == "--nth": nth = int(args[i+1]); i += 2
+        elif args[i] == "--max-depth": max_depth = int(args[i+1]); i += 2
+        elif args[i] == "--max-text": max_text = int(args[i+1]); i += 2
+        else: i += 1
+    b = Builder()
+    with open(path, encoding="utf-8", errors="replace") as f:
+        b.feed(f.read())
+    if substr is None:
+        pp(b.root, 0, max_depth, max_text)
+        return
+    matches = []
+    find(b.root, substr, matches)
+    print(f"# {len(matches)} match(es) for class~='{substr}'", file=sys.stderr)
+    targets = matches if nth is None else [matches[nth]]
+    for t in targets:
+        pp(t, 0, max_depth, max_text)
+        print("-" * 60)
+
+if __name__ == "__main__":
+    main()

--- a/test/test_messagelist.lua
+++ b/test/test_messagelist.lua
@@ -1,0 +1,32 @@
+-- Validates that getMessageList() degrades gracefully when Amazon's
+-- /gp/message page no longer exposes the a-state ajaxToken (new layout,
+-- see the "ajaxToken nil" / 404 crash reported by the user): it must return
+-- an empty result instead of falling through to the broken
+-- "stateData.token" fallback request.
+-- Run: test/run.sh test/test_messagelist.lua
+package.path = "./test/?.lua;" .. package.path
+local mm = require("mm_shim")
+
+local env = mm.loadPlugin("amazon-orders.lua")
+
+-- New-layout /gp/message page: no <script type="...a-state..."> at all.
+local pageWithoutToken = [[
+<html><body>
+<div id="message-center">no ajaxToken here</div>
+</body></html>]]
+
+local calls = 0
+env.connectShop = function(method, url)
+  calls = calls + 1
+  assert(url == "/gp/message", "unexpected request: " .. tostring(url))
+  return mm.HTML(pageWithoutToken)
+end
+
+local orderIds = env.getMessageList(os.time() - 24 * 60 * 60)
+
+local count = 0
+for _ in pairs(orderIds) do count = count + 1 end
+assert(count == 0, "expected no orders from messages, got " .. count)
+assert(calls == 1, "expected getMessageList to stop after the token lookup, got " .. calls .. " requests")
+
+print("TEST_MESSAGELIST OK")

--- a/test/test_parse.lua
+++ b/test/test_parse.lua
@@ -1,0 +1,121 @@
+-- Parsing tests against saved real pages in test/pages/.
+-- Run: test/run.sh test/test_parse.lua
+package.path = "./test/?.lua;" .. package.path
+local mm = require("mm_shim")
+local env = mm.loadPlugin("amazon-orders.lua")
+
+local function readfile(p)
+  local f = assert(io.open(p, "rb")); local s = f:read("*all"); f:close(); return s
+end
+
+local fails = 0
+local function check(cond, msg)
+  if cond then
+    print("  ok  " .. msg)
+  else
+    print("  FAIL " .. msg)
+    fails = fails + 1
+  end
+end
+
+-- Parse a detail page by stubbing the network fetch with saved HTML.
+local function parseDetail(file, orderCode)
+  local pageHtml = readfile("test/pages/" .. file)
+  env.connectShopWithCheck = function() return mm.HTML(pageHtml) end
+  local order = {
+    orderCode = orderCode, orderPositions = {}, orderSum = 0,
+    orderTotal = 0, refund = 0, bookingDate = 0, detailsDate = 0,
+  }
+  env.getOrderDetails(order)
+  return order
+end
+
+local function eur(cents) return string.format("%.2f", cents / 100) end
+local function dump(order)
+  print(string.format("  -> code=%s date=%s total=%s sum=%s positions=%d",
+    order.orderCode, os.date("%Y-%m-%d", order.bookingDate),
+    eur(order.orderTotal), eur(order.orderSum), #order.orderPositions))
+  for i, p in ipairs(order.orderPositions) do
+    print(string.format("     [%d] qty=%s amount=%s  %s", i, tostring(p.qty), eur(p.amount), (p.purpose or ""):sub(1, 60)))
+  end
+  if order.endToEndReference then print("     addr: " .. order.endToEndReference) end
+end
+
+------------------------------------------------------------------ LIST
+print("== list.html: enumerate order codes ==")
+do
+  local html = mm.HTML(readfile("test/pages/list.html"))
+  local orders = env.getOrdersFromSummary(html)
+  local n = 0
+  for code, o in pairs(orders) do
+    n = n + 1
+    check(o.detailsDate == 0, "order " .. code .. " forces detail fetch")
+    check(o.detailsUrl ~= nil and o.detailsUrl ~= "", "order " .. code .. " has detailsUrl")
+  end
+  print("  enumerated " .. n .. " orders")
+  check(n == 10, "expected 10 orders from list page")
+end
+
+------------------------------------------------------------------ SINGLE
+print("== details-single.html ==")
+do
+  local o = parseDetail("details-single.html", "304-1959277-6233165")
+  dump(o)
+  check(os.date("%Y-%m-%d", o.bookingDate) == "2025-12-20", "order date 2025-12-20")
+  check(o.orderTotal == 16998, "orderTotal 169,98")
+  check(#o.orderPositions == 1, "1 position")
+  check(o.orderPositions[1] and o.orderPositions[1].amount == 16998, "position amount 169,98")
+  check(o.orderPositions[1] and o.orderPositions[1].qty == 1, "position qty 1")
+  check(o.orderSum == 16998, "orderSum 169,98")
+  check(o.endToEndReference and o.endToEndReference:find("Chattenweg") ~= nil, "address captured")
+end
+
+------------------------------------------------------------------ MULTI
+print("== details-multi.html ==")
+do
+  local o = parseDetail("details-multi.html", "304-6060868-3893966")
+  dump(o)
+  check(#o.orderPositions == 3, "3 positions")
+  check(o.orderSum == 3397, "orderSum 33,97 (10,99+7,99+14,99)")
+  check(o.orderTotal == 3215, "orderTotal 32,15 (Gesamtsumme, after coupon)")
+  check(o.orderSum - o.orderTotal == 182, "difference 1,82 (coupon)")
+end
+
+------------------------------------------------------------------ REFUND
+print("== details-multi-with-refund.html ==")
+do
+  local o = parseDetail("details-multi-with-refund.html", "?")
+  dump(o)
+  check(#o.orderPositions == 4, "4 positions")
+  check(o.orderTotal == 5250, "orderTotal 52,50 (not the refund row)")
+  check(o.refundTransactions ~= nil, "refund captured")
+  if o.refundTransactions then
+    local total = 0
+    for d, amounts in pairs(o.refundTransactions) do
+      for amount, _ in pairs(amounts) do total = total + amount end
+    end
+    check(total == 673, "refund amount 6,73")
+  end
+end
+
+------------------------------------------------------------------ DIGITAL
+print("== details-digital.html ==")
+do
+  local o = parseDetail("details-digital.html", "?")
+  dump(o)
+  check(#o.orderPositions == 1, "1 position")
+  check(o.orderTotal == 995, "orderTotal 9,95")
+  check(o.orderSum == 995, "orderSum 9,95")
+end
+
+------------------------------------------------------------------ GIFT CARD
+print("== details-giftcard.html ==")
+do
+  local o = parseDetail("details-giftcard.html", "?")
+  dump(o)
+  check(#o.orderPositions == 1, "1 position")
+  check(o.orderTotal == 1500, "orderTotal 15,00")
+end
+
+print(string.rep("-", 50))
+if fails == 0 then print("ALL TESTS PASSED") else print(fails .. " CHECK(S) FAILED"); os.exit(1) end

--- a/test/test_parse.lua
+++ b/test/test_parse.lua
@@ -117,5 +117,18 @@ do
   check(o.orderTotal == 1500, "orderTotal 15,00")
 end
 
+------------------------------------------------------------------ QTY > 1
+print("== details-quantity-other-than-1.html ==")
+do
+  local o = parseDetail("details-quantity-other-than-1.html", "304-2173771-7757910")
+  dump(o)
+  check(#o.orderPositions == 1, "1 position")
+  check(o.orderPositions[1] and o.orderPositions[1].qty == 2, "quantity 2 (from badge)")
+  check(o.orderPositions[1] and o.orderPositions[1].amount == 1159, "unit price 11,59")
+  check(o.orderSum == 2318, "orderSum 23,18 (2 x 11,59)")
+  check(o.orderTotal == 2086, "orderTotal 20,86 (Gesamtsumme after coupon)")
+  check(o.orderSum - o.orderTotal == 232, "difference 2,32 (coupon)")
+end
+
 print(string.rep("-", 50))
 if fails == 0 then print("ALL TESTS PASSED") else print(fails .. " CHECK(S) FAILED"); os.exit(1) end


### PR DESCRIPTION
Fixes #68 

This also adds a `test` directory with scripts to run the extraction against manually downloaded order details pages to verify the extraction against future changes. Not sure this is desired in the official repo though.